### PR TITLE
Remove requests dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,10 @@ After setting up your environment, verify the installation:
 python --version
 
 # Check installed packages
-pip list | grep -E "(cfgrib|xarray|pandas|numpy|scipy|requests)"
+pip list | grep -E "(cfgrib|xarray|pandas|numpy|scipy)"
 
 # Test import
-python -c "import cfgrib, xarray, pandas, numpy, scipy, requests; print('All packages imported successfully!')"
+python -c "import cfgrib, xarray, pandas, numpy, scipy; print('All packages imported successfully!')"
 ```
 
 ---
@@ -364,7 +364,7 @@ python raw_data_viewer.py
 - Check Python environment has all required packages
 
 **Import errors:**
-- Verify all dependencies are installed: `pip list | grep -E "(cfgrib|xarray|pandas|numpy|scipy|requests)"`
+ - Verify all dependencies are installed: `pip list | grep -E "(cfgrib|xarray|pandas|numpy|scipy)"`
 - Consider using a virtual environment
 
 **Environment issues:**

--- a/raw_data_viewer.py
+++ b/raw_data_viewer.py
@@ -125,10 +125,11 @@ def find_latest_available_run_hour(forecast_hour, model_type):
             base_url = "https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod"
             file_url = f"{base_url}/gfs.{file_date}/{run_hour:02d}/{filename}"
             try:
-                import requests
-                r = requests.head(file_url, timeout=5)
-                if r.status_code == 200:
-                    return file_date, run_hour, filename
+                from urllib.request import Request, urlopen
+                req = Request(file_url, method="HEAD")
+                with urlopen(req, timeout=5) as r:
+                    if r.status == 200:
+                        return file_date, run_hour, filename
             except Exception:
                 continue
         # Fallback to current hour if nothing found
@@ -150,10 +151,11 @@ def find_latest_available_run_hour(forecast_hour, model_type):
             base_url = "https://nomads.ncep.noaa.gov/pub/data/nccf/com/hrrr/prod"
             file_url = f"{base_url}/hrrr.{file_date}/conus/{filename}"
             try:
-                import requests
-                r = requests.head(file_url, timeout=5)
-                if r.status_code == 200:
-                    return file_date, run_hour, filename
+                from urllib.request import Request, urlopen
+                req = Request(file_url, method="HEAD")
+                with urlopen(req, timeout=5) as r:
+                    if r.status == 200:
+                        return file_date, run_hour, filename
             except Exception:
                 continue
         # Fallback to current hour if nothing found

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ xarray
 pandas
 numpy
 scipy
-requests


### PR DESCRIPTION
## Summary
- use `urllib` instead of `requests.head` when checking remote forecast files
- drop `requests` requirement
- update docs to remove `requests` from environment verification

## Testing
- `python -m py_compile raw_data_viewer.py wind_profiler.py`

------
https://chatgpt.com/codex/tasks/task_e_6860a05a852083339242793a3b09bcce